### PR TITLE
Clean up dependencies and add site title link in top nav bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 .jekyll-metadata
 .DS_Store
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,6 @@ ruby RUBY_VERSION
 # Happy Jekylling!
 gem "jekyll"
 
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", "~> 2.0"
-
 # i really don't understand why this is necessary but whatever
 gem "kramdown-parser-gfm"
 gem "webrick"

--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,12 @@ ruby RUBY_VERSION
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll"
+gem "jekyll", "~> 3.10.0"
 
 # i really don't understand why this is necessary but whatever
 gem "kramdown-parser-gfm"
-gem "webrick"
+gem "base64"
+gem "bigdecimal"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,44 +3,52 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.2.0)
     bigdecimal (3.1.8)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
+    csv (3.3.0)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
+    ffi (1.17.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
     ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    google-protobuf (4.28.2-arm64-darwin)
-      bigdecimal
-      rake (>= 13)
     http_parser.rb (0.8.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.4)
+    jekyll (3.10.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
+      csv (~> 3.0)
       em-websocket (~> 0.5)
-      i18n (~> 1.0)
-      jekyll-sass-converter (>= 2.0, < 4.0)
+      i18n (>= 0.7, < 2)
+      jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 2.0)
-      kramdown (~> 2.3, >= 2.3.1)
-      kramdown-parser-gfm (~> 1.0)
+      kramdown (>= 1.17, < 3)
       liquid (~> 4.0)
-      mercenary (>= 0.3.6, < 0.5)
+      mercenary (~> 0.3.3)
       pathutil (~> 0.9)
-      rouge (>= 3.0, < 5.0)
+      rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-      terminal-table (>= 1.8, < 4.0)
-      webrick (~> 1.7)
-    jekyll-feed (0.15.1)
+      webrick (>= 1.0)
+    jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.1)
+    kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -48,33 +56,43 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    mercenary (0.4.0)
+    mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
-    rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
-    rouge (4.4.0)
+    rexml (3.3.8)
+    rouge (3.30.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.79.4-arm64-darwin)
-      google-protobuf (~> 4.27)
-    terminal-table (3.0.2)
-      unicode-display_width (>= 1.1.1, < 3)
-    unicode-display_width (2.6.0)
-    webrick (1.7.0)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    webrick (1.8.2)
 
 PLATFORMS
-  arm64-darwin-23
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
-  jekyll
+  base64
+  bigdecimal
+  jekyll (~> 3.10.0)
   jekyll-feed (~> 0.9)
   kramdown-parser-gfm
   tzinfo-data
-  webrick
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,85 +1,83 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    bigdecimal (3.1.8)
     colorator (1.1.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.3.4)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.15.4)
+    ffi (1.17.0-arm64-darwin)
     forwardable-extended (2.6.0)
+    google-protobuf (4.28.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
     http_parser.rb (0.8.0)
-    i18n (0.9.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    jekyll (3.9.0)
+    jekyll (4.3.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
-      i18n (~> 0.7)
-      jekyll-sass-converter (~> 1.0)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
-      kramdown (>= 1.17, < 3)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.3.3)
+      mercenary (>= 0.3.6, < 0.5)
       pathutil (~> 0.9)
-      rouge (>= 1.7, < 4)
+      rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-sass-converter (1.5.2)
-      sass (~> 3.4)
-    jekyll-seo-tag (2.7.1)
-      jekyll (>= 3.8, < 5.0)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    liquid (4.0.3)
-    listen (3.7.0)
+    liquid (4.0.4)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    mercenary (0.3.6)
-    minima (2.5.1)
-      jekyll (>= 3.5, < 5.0)
-      jekyll-feed (~> 0.9)
-      jekyll-seo-tag (~> 2.1)
+    mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.6)
-    rb-fsevent (0.11.0)
-    rb-inotify (0.10.1)
+    public_suffix (6.0.1)
+    rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (3.26.1)
+    rouge (4.4.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+    sass-embedded (1.79.4-arm64-darwin)
+      google-protobuf (~> 4.27)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
     webrick (1.7.0)
 
 PLATFORMS
   arm64-darwin-23
-  universal-darwin-18
-  universal-darwin-22
-  x86_64-darwin-21
 
 DEPENDENCIES
   jekyll
   jekyll-feed (~> 0.9)
   kramdown-parser-gfm
-  minima (~> 2.0)
   tzinfo-data
   webrick
 
 RUBY VERSION
-   ruby 3.1.6p260
+   ruby 3.3.0p0
 
 BUNDLED WITH
    2.5.11

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 Inter
 
 # local testing
 
+You might need to run this command before building anything to ensure that Ruby installs gems into your user directory, not a global directory that sometimes maybe kinda sort requires `sudo`:
+
+```bash
+bundle config path ~/.gem/ruby
+```
+
 To test this site locally, install jekyll (note: this requires ruby)
 (note: you might need to preface this with `sudo`):
 

--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,6 @@ kramdown:
   syntax_highlighter: rouge
   typographic_symbols: { hellip: ... , mdash: --- , ndash: -- , laquo: "<<" , raquo: ">>" , laquo_space: "<< " , raquo_space: " >>" }
   smart_quotes: apos,apos,quot,quot
-theme: minima
 plugins:
   - jekyll-feed
 exclude:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,7 +67,7 @@
         <nav>
           <div class="biglambda">
             <div class="biglambdacontent">
-              &#955; Latitudinarians
+              <a class="nostyle nohover" href="/">&#955; Latitudinarians</a>
               <spacer></spacer>
               <mobile-menu-toggle>
                 <label for="menuToggle"><span>&#9660; MENU</span></label>

--- a/_posts/techblog/2023-11-20-book-review-the-lost-cause.md
+++ b/_posts/techblog/2023-11-20-book-review-the-lost-cause.md
@@ -1,5 +1,5 @@
 ---
-title:  "Book Review: The Lost Cause"
+title:  "Book Review: <i>The Lost Cause</i>"
 date:   2023-11-20 13:17:53 -0500
 layout: default
 categories: techblog

--- a/_stylesheets/lite.css
+++ b/_stylesheets/lite.css
@@ -527,3 +527,14 @@ nav {
 .PageNavigation .prev::before {
   content: "<<";
 }
+
+/* no style links -- used for nav header */
+a.nostyle:link {
+    text-decoration: inherit;
+    color: inherit;
+}
+
+a.nostyle:visited {
+    text-decoration: inherit;
+    color: inherit;
+}


### PR DESCRIPTION
Unfortunately, it looks like GitHub pages is still stuck on Jekyll 3.10, so there's no way forward to 4.3.3.

Fortunately, Jekyll is already fully-featured so who cares?

Pushing this so I can harvest the useful pieces -- notably:

* remove the minima theme (this site defines a custom CSS-based theme so minima goes totally unused)
* make the site title in the top nav bar a link, because I kind of expect sites to do that even though it doesn't matter all that much
* add a css class to leave the site title styling alone despite it being a link

Update: bumped jekyll to the latest GitHub Pages version. Updated dependencies for compat.